### PR TITLE
Refactor CsvProcessor into smaller methods

### DIFF
--- a/backend/app/services/csv_processor.rb
+++ b/backend/app/services/csv_processor.rb
@@ -18,89 +18,94 @@ class CsvProcessor
 
   def process
     max_lines = ENV.fetch("CSV_MAX_LINES").to_i
-    line_count = 0
     valid_rows = 0
     skipped_rows = 0
     products = []
+    line_number = 0
 
-    # Iterate over each row in the CSV file using a semicolon as the column separator
-    CSV.foreach(@file_path, headers: true, col_sep: ';') do |row|
-      line_count += 1
-      if line_count > max_lines
-        Rails.logger.warn("CSV file exceeded the maximum allowed lines (#{max_lines}). Stopping processing.")
-        break
-      end
-
+    parse_rows.each do |ln, row|
+      line_number = ln
+      break if line_number > max_lines
       begin
-        name = row['name']&.strip
-        price_str = row['price']&.strip
-        expiration_str = row['expiration']&.strip
-
-        # Check that required fields are present
-        unless name.present? && price_str.present? && expiration_str.present?
-          error_message = "Missing required fields. name: #{name.inspect}, price: #{price_str.inspect}, expiration: #{expiration_str.inspect}"
-          log_failed_row(line_count, row, error_message)
+        validated = validate_row(line_number, row)
+        if validated
+          sanitized = sanitize_row(validated)
+          products << sanitized.merge(
+            exchange_rates: @exchange_rates,
+            created_at: Time.current,
+            updated_at: Time.current
+          )
+          valid_rows += 1
+          products = batch_insert(products, line_number)
+        else
           skipped_rows += 1
-          next
-        end
-
-        # Remove any HTML tags from the name field
-        name = strip_tags(name)
-        # Sanitize any occurrences of #(…) in the name field:
-        # If the content inside is not numeric, it will be replaced by "#()"
-        name = sanitize_numeric_hash_content(name)
-
-        # Sanitize the price string: remove non-numeric characters except comma and dot
-        sanitized_price = price_str.gsub(/[^\d,\.]/, '')
-        # Convert to a BigDecimal (replace comma with dot if necessary)
-        price = sanitized_price.tr(',', '.').to_d rescue nil
-        unless price
-          error_message = "Invalid price format (#{price_str.inspect} sanitized to #{sanitized_price.inspect})."
-          log_failed_row(line_count, row, error_message)
-          skipped_rows += 1
-          next
-        end
-
-        # Parse the expiration date from the provided string (format: MM/DD/YYYY)
-        expiration = Date.strptime(expiration_str, '%m/%d/%Y') rescue nil
-        unless expiration
-          error_message = "Invalid expiration date format (#{expiration_str.inspect})."
-          log_failed_row(line_count, row, error_message)
-          skipped_rows += 1
-          next
-        end
-
-        # Prepare the product data hash for bulk insertion
-        products << {
-          name: name,
-          price: price,
-          expiration: expiration,
-          exchange_rates: @exchange_rates,
-          created_at: Time.current,
-          updated_at: Time.current
-        }
-        valid_rows += 1
-
-        # Insert products in batches of 1000
-        if products.size >= 1000
-          Product.insert_all(products)
-          Rails.logger.info("Batch insert: inserted #{products.size} products (up to row #{line_count}).")
-          products = []
         end
       rescue StandardError => row_error
-        error_message = "Exception: #{row_error.message}"
-        log_failed_row(line_count, row, error_message)
-        Rails.logger.error("Error processing row ##{line_count}: #{row.inspect}. Error: #{row_error.message}")
+        log_failed_row(line_number, row, "Exception: #{row_error.message}")
+        Rails.logger.error("Error processing row ##{line_number}: #{row.inspect}. Error: #{row_error.message}")
         skipped_rows += 1
       end
     end
 
-    # Insert any remaining products
     Product.insert_all(products) if products.any?
-    Rails.logger.info("Processed #{line_count} lines: inserted #{valid_rows} products and skipped #{skipped_rows} rows from file #{@file_path}.")
+    Rails.logger.info(
+      "Processed #{line_number} lines: inserted #{valid_rows} products and skipped #{skipped_rows} rows from file #{@file_path}."
+    )
   end
 
   private
+
+  def parse_rows
+    return enum_for(:parse_rows) unless block_given?
+    line_number = 0
+    CSV.foreach(@file_path, headers: true, col_sep: ';') do |row|
+      line_number += 1
+      yield line_number, row
+    end
+  end
+
+  def validate_row(line_number, row)
+    name = row['name']&.strip
+    price_str = row['price']&.strip
+    expiration_str = row['expiration']&.strip
+
+    unless name.present? && price_str.present? && expiration_str.present?
+      error_message = "Missing required fields. name: #{name.inspect}, price: #{price_str.inspect}, expiration: #{expiration_str.inspect}"
+      log_failed_row(line_number, row, error_message)
+      return nil
+    end
+
+    sanitized_price = price_str.gsub(/[^\d,\.]/, '')
+    price = sanitized_price.tr(',', '.').to_d rescue nil
+    unless price
+      error_message = "Invalid price format (#{price_str.inspect} sanitized to #{sanitized_price.inspect})."
+      log_failed_row(line_number, row, error_message)
+      return nil
+    end
+
+    expiration = Date.strptime(expiration_str, '%m/%d/%Y') rescue nil
+    unless expiration
+      error_message = "Invalid expiration date format (#{expiration_str.inspect})."
+      log_failed_row(line_number, row, error_message)
+      return nil
+    end
+
+    { name: name, price: price, expiration: expiration }
+  end
+
+  def sanitize_row(data)
+    sanitized_name = strip_tags(data[:name])
+    sanitized_name = sanitize_numeric_hash_content(sanitized_name)
+    { name: sanitized_name, price: data[:price], expiration: data[:expiration] }
+  end
+
+  def batch_insert(products, line_number)
+    return products unless products.size >= 1000
+
+    Product.insert_all(products)
+    Rails.logger.info("Batch insert: inserted #{products.size} products (up to row #{line_number}).")
+    []
+  end
 
   # Logs a failed row into the failed_rows CSV file with the line number, row data, and error message.
   def log_failed_row(line_number, row, error_message)


### PR DESCRIPTION
## Summary
- refactor `CsvProcessor#process` into helper methods
- add `parse_rows`, `validate_row`, `sanitize_row`, `batch_insert`, and use them in process
- expand CsvProcessor specs to cover new methods and set `CSV_MAX_LINES` for tests

## Testing
- `bundle exec rspec spec/services/csv_processor_spec.rb` *(fails: ruby-3.2.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f83aac61883219a79a33a2681af77